### PR TITLE
fix for pandoc 1.14 - \tightlist not defined

### DIFF
--- a/pweave/formatters.py
+++ b/pweave/formatters.py
@@ -571,6 +571,9 @@ class PwebPandoctoTexFormatter(PwebTexPygmentsFormatter):
         }
         \\setlength{\parindent}{0pt}
         \\setlength{\parskip}{1.2ex}
+        %% fix for pandoc 1.14
+        \\providecommand{\\tightlist}{%%
+            \\setlength{\\itemsep}{0pt}\\setlength{\\parskip}{0pt}}
         %s
         """) % (self.source, x.get_style_defs())
         self.footer = r"\end{document}"


### PR DESCRIPTION
Pandoc generates lists with \tightlist, which is not available with the latex packages Pweave uses.

There's more info [here](https://github.com/osener/markup.rocks/issues/4).

This patch fixes this by defining the \tightlist command