### PR TITLE
Fix some installation errors when the dependencies wasn't installed before

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,8 @@ setup(name='Pweave',
       author_email='matti.pastell@helsinki.fi',
       url='http://mpastell.com/pweave',
       packages=['pweave', 'pweave.themes', 'pweave.formatters', 'pweave.processors'],
+      install_requires = ['markdown', 'pygments', 'ipython', 'nbformat',
+                          'nbconvert', 'jupyter_client'],
       license='LICENSE.txt',
       long_description = read('README.rst'),
       classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,21 @@
 #!/usr/bin/env python
 from setuptools import setup
 import os
-import pweave
+import ast
+
+HERE = os.path.abspath(os.path.dirname(__file__))
+
+def get_version():
+    """Get version."""
+    with open(os.path.join(HERE, 'pweave', '__init__.py'), 'r') as f:
+        data = f.read()
+    lines = data.split('\n')
+    for line in lines:
+        if line.startswith('__version__'):
+            version_tuple = ast.literal_eval(line.split('=')[-1].strip())
+            version = '.'.join(map(str, version_tuple))
+            break
+    return version
 
 
 def read(fname):
@@ -17,7 +31,7 @@ setup(name='Pweave',
                'pypublish = pweave.scripts:publish',
                'pweave-convert = pweave.scripts:convert'
                ]},
-      version = pweave.__version__,
+      version = get_version(),
       description='Scientific reports with embedded python computations with reST, LaTeX or markdown',
       author='Matti Pastell',
       author_email='matti.pastell@helsinki.fi',


### PR DESCRIPTION
This PR fixes two bugs with the setup.py

- Install Pweave form source cause error because it tries to import the module in the setup.py

```
$ python setup.py install
Traceback (most recent call last):
  File "setup.py", line 4, in <module>
    import pweave
  File "/home/rlaverde/code/Pweave/pweave/__init__.py", line 7, in <module>
    from .pweb import *
  File "/home/rlaverde/code/Pweave/pweave/pweb.py", line 8, in <module>
    from . formatters import PwebFormats
  File "/home/rlaverde/code/Pweave/pweave/formatters/__init__.py", line 1, in <module>
    from .tex import PwebTexFormatter, PwebMintedFormatter, \
  File "/home/rlaverde/code/Pweave/pweave/formatters/tex.py", line 1, in <module>
    from .base import PwebFormatter
  File "/home/rlaverde/code/Pweave/pweave/formatters/base.py", line 5, in <module>
    from nbconvert import filters
ImportError: No module named 'nbconvert'
```

- The installation doesn't install the dependencies, so, after installing pweave, trying to run it cause a similar error:

```
$ pweave --version
Traceback (most recent call last):
  File "/home/rlaverde/envs/test-pweave/bin/pweave", line 11, in <module>
    load_entry_point('Pweave===0...3.0.-.a.l.p.h.a.1', 'console_scripts', 'pweave')()
  File "/home/rlaverde/envs/test-pweave/lib/python3.5/site-packages/pkg_resources/__init__.py", line 563, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/home/rlaverde/envs/test-pweave/lib/python3.5/site-packages/pkg_resources/__init__.py", line 2651, in load_entry_point
    return ep.load()
  File "/home/rlaverde/envs/test-pweave/lib/python3.5/site-packages/pkg_resources/__init__.py", line 2305, in load
    return self.resolve()
  File "/home/rlaverde/envs/test-pweave/lib/python3.5/site-packages/pkg_resources/__init__.py", line 2311, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "/home/rlaverde/envs/test-pweave/lib/python3.5/site-packages/Pweave-0...3.0._.a.l.p.h.a.1-py3.5.egg/pweave/__init__.py", line 7, in <module>
  File "/home/rlaverde/envs/test-pweave/lib/python3.5/site-packages/Pweave-0...3.0._.a.l.p.h.a.1-py3.5.egg/pweave/pweb.py", line 8, in <module>
  File "/home/rlaverde/envs/test-pweave/lib/python3.5/site-packages/Pweave-0...3.0._.a.l.p.h.a.1-py3.5.egg/pweave/formatters/__init__.py", line 1, in <module>
  File "/home/rlaverde/envs/test-pweave/lib/python3.5/site-packages/Pweave-0...3.0._.a.l.p.h.a.1-py3.5.egg/pweave/formatters/tex.py", line 1, in <module>
  File "/home/rlaverde/envs/test-pweave/lib/python3.5/site-packages/Pweave-0...3.0._.a.l.p.h.a.1-py3.5.egg/pweave/formatters/base.py", line 5, in <module>
ImportError: No module named 'nbconvert'
```



