### PR TITLE
Fix error when opening a file in windows.

### DIFF
--- a/pweave/readers.py
+++ b/pweave/readers.py
@@ -9,11 +9,14 @@ from urllib import request, parse
 
 
 def read_file_or_url(source):
-    if parse.urlparse(source).scheme == "":
+    """
+    Try to open path as a file, and if its fails open it as url.
+    """
+    try:
         codefile = io.open(source, 'r', encoding='utf-8')
         contents = codefile.read()
         codefile.close()
-    else:
+    except IOError:
         r = request.urlopen(source)
         contents = r.read().decode("utf-8")
         r.close()


### PR DESCRIPTION
Windows files was detected as urls https://github.com/mpastell/Pweave/blob/master/pweave/readers.py#L12

```
>>>from urllib import parse
>>>source = "C:\WinPython\basedir35"
>>>parse.urlparse(source).scheme
'c'
```

See spyder-reports issue: https://github.com/spyder-ide/spyder-reports/issues/27

is ok this fix with the `try.. except`? according to [this stackoverflow comment](https://stackoverflow.com/a/11687957/1335555) It's better to accept file-like objects, instead of paths; but this will cause a change in the API