### PR TITLE
Add Python 36

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: python
-python:
-  - 3.5
+
+matrix:
+  include:
+    - python: "3.5"
+    - python: "3.6"
+
 notifications:
   email: false
 

--- a/setup.py
+++ b/setup.py
@@ -34,8 +34,8 @@ setup(name='Pweave',
         'Topic :: Documentation :: Sphinx',
         'License :: OSI Approved :: BSD License',
         'Programming Language :: Python :: 3 :: Only',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5'
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         ]
 
 )


### PR DESCRIPTION
- Remove python3.4 classifier
- Add python3.6 classifier
- Add python3.6 to build matrix, is this ok? or should I replace 3.5

related to #66 