### PR TITLE
Add test requirements to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,8 @@ setup(name='Pweave',
       packages=['pweave', 'pweave.themes', 'pweave.formatters', 'pweave.processors', 'pweave.bokeh'],
       install_requires = ['markdown', 'pygments', 'ipython', 'nbformat',
                           'nbconvert', 'jupyter_client', 'ipykernel'],
+      extras_require = {'test': ['scipy', 'matplotlib', 'coverage',
+                                   'ipython', 'nose', 'notebook']},
       license='LICENSE.txt',
       long_description = read('README.rst'),
       classifiers=[


### PR DESCRIPTION
See: #55 

This will allow to install pweave with test dependencies using:

`pip install Pweave[test]`

Tests also use pandoc, but it isn't a python package