### PR TITLE
Add the change log to the release tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,3 @@
-include LICENSE.txt
+include LICENSE.txt CHANGELOG.txt
 recursive-include tests *
 recursive-include doc *


### PR DESCRIPTION
As recommended by Debian and other Linux distributions. Helps package maintainers to review changes introduced with a new release without having to inspect the whole diff of the source tree.