### PR TITLE
Filter bytecode files from the release tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include LICENSE.txt
 recursive-include tests *
 recursive-include doc *
+global-exclude *.py[co]


### PR DESCRIPTION
The current release on PyPI (version 0.30.1) contains spurious bytecode files. This pattern will ensure these are excluded in the future. Please consider uploading a curated tarball to PyPI, probably in the form of a new bugfix release.

Cheers,