### PR TITLE
Add CLI flag to exit on exception

### DIFF
--- a/pweave/__init__.py
+++ b/pweave/__init__.py
@@ -14,7 +14,7 @@ from .config import *
 __version__ = '0.30.2'
 
 def weave(file, doctype=None, informat=None, kernel="python3", plot=True,
-          docmode=False, cache=False,
+          docmode=False, cache=False, exceptionexit=False,
           figdir='figures', cachedir='cache',
           figformat=None, listformats=False,
           output=None, mimetype=None,):
@@ -28,6 +28,7 @@ def weave(file, doctype=None, informat=None, kernel="python3", plot=True,
     :param plot: ``bool`` use matplotlib
     :param docmode: ``bool`` use documentation mode, chunk code and results will be loaded from cache and inline code will be hidden
     :param cache: ``bool`` Cache results to disk for documentation mode
+    :param exitonexception: ``bool`` Exit when an exception is raised in a code chunk
     :param figdir: ``string`` directory path for figures
     :param cachedir: ``string`` directory path for cached results used in documentation mode
     :param figformat: ``string`` format for saved figures (e.g. '.png'), if None then the default for each format is used
@@ -55,6 +56,7 @@ def weave(file, doctype=None, informat=None, kernel="python3", plot=True,
     rcParams["usematplotlib"] = plot
     rcParams["cachedir"] = cachedir
     rcParams["storeresults"] = cache
+    rcParams["exceptionexit"] = exceptionexit
 
     doc.weave()
 

--- a/pweave/processors/jupyter.py
+++ b/pweave/processors/jupyter.py
@@ -4,6 +4,7 @@ from jupyter_client.manager import start_new_kernel
 from jupyter_client import KernelManager
 from nbformat.v4 import output_from_msg
 import os
+import sys
 
 from .. import config
 from .base import PwebProcessorBase
@@ -54,6 +55,14 @@ class JupyterProcessor(PwebProcessorBase):
 
     def run_cell(self, src):
         cell = {}
+
+        # Clear the last unhandled exception, if it is set
+        try:
+            if sys.last_value:
+                sys.last_value == None 
+        except AttributeError:
+            pass
+          
         cell["source"] = src.lstrip()
         msg_id = self.kc.execute(src.lstrip(), store_history=False)
 
@@ -128,6 +137,12 @@ class JupyterProcessor(PwebProcessorBase):
             else:
                 outs.append(out)
 
+        if config.rcParams["exceptionexit"]:
+            try:
+                raise sys.last_value
+            except AttributeError:
+                pass
+            
         return outs
 
     def loadstring(self, code_str, **kwargs):

--- a/pweave/scripts.py
+++ b/pweave/scripts.py
@@ -29,6 +29,8 @@ def weave():
     parser.add_option("-c", "--cache-results", dest="cache",
                       action="store_true", default=False,
                       help="Cache results to disk for documentation mode")
+    parser.add_option("-e", "--exit-on-exception", action="store_true", dest="exceptionexit", default=False,
+                      help="Exit when an exception is encountered in a code chunk. This is only supported by python3 in a Jupyter kernel")
     parser.add_option("-F", "--figure-directory", dest="figdir", default='figures',
                       help="Directory path for matplolib graphics: Default 'figures'")
     parser.add_option("--cache-directory", dest="cachedir", default='cache',


### PR DESCRIPTION
This adds a flag to exit on exception (#100). I've only tested this with Python 3 in the Jupyter engine. I wasn't able to find a clean way to handle exceptions in general from Jupyter, so I fell back to checking [sys.last_value](https://docs.python.org/3.5/library/sys.html#sys.last_value) (the last unhandled exception object). This seems to work fine in the light testing that I've done.

I'm definitely open to better ways to do this or any other feedback.