### PR TITLE
When reading chunks from an external file, prepend the current working directory.

### DIFF
--- a/pweave/processors/base.py
+++ b/pweave/processors/base.py
@@ -107,11 +107,12 @@ class PwebProcessorBase(object):
 
             # Read the content from file or object
         if 'source' in chunk:
-            source = chunk["source"]
-            if os.path.isfile(source):
+            if os.path.isfile(os.path.join(self.cwd, chunk['source'])):
+                source = os.path.join(self.cwd, chunk['source'])
                 chunk["content"] = "\n" + io.open(source, "r", encoding='utf-8').read().rstrip() + "\n" + chunk[
                     'content']
             else:
+                source = chunk["source"]
                 chunk_text = chunk["content"]  # Get the text from chunk
                 module_text = self.loadstring(
                     "import inspect\nprint(inspect.getsource(%s))" % source)  # Get the module source using inspect

--- a/pweave/processors/base.py
+++ b/pweave/processors/base.py
@@ -105,7 +105,7 @@ class PwebProcessorBase(object):
             chunk["options"] = defaults
             #del chunk['options']
 
-            # Read the content from file or object
+        # Read the content from file or object
         if 'source' in chunk:
             if os.path.isfile(os.path.join(self.cwd, chunk['source'])):
                 source = os.path.join(self.cwd, chunk['source'])


### PR DESCRIPTION
Previously, it was not possible to run pweave in such cases unless we're in the right working directory already.

I would ordinarily include a test case but there is no obvious place to put it -- there are no rstw test cases currently in the regression test suite. Your guidance here would be welcome.