### PR TITLE
 Fixed handling of non-executed cells in jupyter notebooks

### DIFF
--- a/pweave/formatters/jupyter_notebook.py
+++ b/pweave/formatters/jupyter_notebook.py
@@ -47,10 +47,14 @@ class PwebNotebookFormatter(object):
                     }
                 )
             if chunk["type"] == "code":
+                if chunk["evaluate"]:
+                    ec = self.execution_count
+                else:
+                    ec = None
                 self.notebook["cells"].append(
                     {
                         "cell_type": "code",
-                        "execution_count" : self.execution_count,
+                        "execution_count" : ec,
                         "metadata": {
                             "collapsed": False,
                             "autoscroll": "auto",
@@ -60,7 +64,8 @@ class PwebNotebookFormatter(object):
                         "outputs" : chunk["result"]
                     }
                 )
-                self.execution_count +=1
+                if chunk['evaluate']:
+                    self.execution_count +=1
         self.notebook = nbformat.from_dict(self.notebook)
 
     def getformatted(self):

--- a/pweave/processors/base.py
+++ b/pweave/processors/base.py
@@ -138,7 +138,7 @@ class PwebProcessorBase(object):
                 self.pending_code = ""
 
             if not chunk['evaluate']:
-                chunk['result'] = ''
+                chunk['result'] = ""
                 return chunk
 
             self.pre_run_hook(chunk)

--- a/pweave/processors/base.py
+++ b/pweave/processors/base.py
@@ -138,7 +138,7 @@ class PwebProcessorBase(object):
                 self.pending_code = ""
 
             if not chunk['evaluate']:
-                chunk['result'] = ""
+                chunk['result'] = []
                 return chunk
 
             self.pre_run_hook(chunk)

--- a/pweave/pweb.py
+++ b/pweave/pweb.py
@@ -29,6 +29,7 @@ class Pweb(object):
 
     def __init__(self, source, doctype = None, *, informat = None, kernel = "python3",
                  output = None, figdir = 'figures', mimetype = None):
+
         self.source = source
         name, ext = os.path.splitext(os.path.basename(source))
         self.basename = name


### PR DESCRIPTION
When writing to a Jupyter notebook, if a code cell had the option 'execute=False', I would get the following error:

```
Failed validating 'type' in code_cell['properties']['outputs']:                                                  

On instance['cells'][1]['outputs']:
''
```

This was fixed by changing the result from `''` to `[]`.
Also, the execution count for non-executed cells was set to `None`.

I haven't tested if this causes undesirable behavior for other output formats.