### PR TITLE
Fix the issue of empty result on newer IPython

### DIFF
--- a/pweave/processors/jupyter.py
+++ b/pweave/processors/jupyter.py
@@ -120,6 +120,8 @@ class JupyterProcessor(PwebProcessorBase):
                 continue
             elif msg_type.startswith('comm'):
                 continue
+            elif msg_type == 'execute_reply':
+                continue
 
             try:
                 out = output_from_msg(msg)


### PR DESCRIPTION
This should solve #132 . Basically ipython5 added a new type of message reply and that breaks the pweave.

In fact, I was wondering if we should change to capture only the `stream` response. But that has the limitation of no parent `msg_id`... :(