### PR TITLE
`-R` option has been removed from pandoc.

### DIFF
--- a/pweave/formatters/publish.py
+++ b/pweave/formatters/publish.py
@@ -252,7 +252,7 @@ class PwebPandoctoTexFormatter(PwebTexPygmentsFormatter):
         if 'number' in chunk and chunk['number'] == 1:
             chunk = self.parsetitle(chunk)
         try:
-            pandoc = Popen(["pandoc", "-R", "-t", "latex", "-f", "markdown"], stdin=PIPE, stdout=PIPE)
+            pandoc = Popen(["pandoc", "-t", "latex+raw_tex", "-f", "markdown"], stdin=PIPE, stdout=PIPE)
         except:
             sys.stderr.write("ERROR: Can't find pandoc")
             raise


### PR DESCRIPTION
In pdf writer (`pypublish`), pandoc still uses `-R` option which has been removed. It does not compile with version 2.7 (Arch Linux). This PR removes `-R` and added extension `+raw_tex` to the command.

