### PR TITLE
Fix theme argument to publish

### DIFF
--- a/pweave/__init__.py
+++ b/pweave/__init__.py
@@ -88,9 +88,7 @@ def publish(file, doc_format="html", theme="skeleton", latex_engine="pdflatex",
         return
 
     doc = Pweb(file, kernel="python3", doctype=pformat,
-               output=output)
-
-    doc.theme = theme
+               output=output, theme=theme)
 
     doc.read()
     doc.run()

--- a/pweave/pweb.py
+++ b/pweave/pweb.py
@@ -25,10 +25,11 @@ class Pweb(object):
     :param figdir: ``string`` figure directory
     :param mimetype: Source document's text mimetype. This is used to set cell
                      type in Jupyter notebooks
+    :param theme: ``string`` html theme
     """
 
     def __init__(self, source, doctype = None, *, informat = None, kernel = "python3",
-                 output = None, figdir = 'figures', mimetype = None):
+                 output = None, figdir = 'figures', mimetype = None, theme = "skeleton"):
         self.source = source
         name, ext = os.path.splitext(os.path.basename(source))
         self.basename = name
@@ -63,7 +64,7 @@ class Pweb(object):
         self.formatted = None
         self.reader = None
         self.formatter = None
-        self.theme = "skeleton"
+        self.theme = theme
 
         self.setformat(doctype)
         self.read(reader = informat)


### PR DESCRIPTION
The theme argument to `publish` is currently ignored, causing all documents to render in the default skeleton theme. The issue is that `Pweb` loads its theme in `__init__`, when it calls `setformat`, before `publish` has a chance to set the theme.

PR solves this by passing theme to `Pweb.__init__` instead.